### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/gui/lv_100ask_xz_ai/src/cJSON.c
+++ b/gui/lv_100ask_xz_ai/src/cJSON.c
@@ -401,7 +401,12 @@ CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring)
 {
     char *copy = NULL;
     /* if object's type is not cJSON_String or is cJSON_IsReference, it should not set valuestring */
-    if (!(object->type & cJSON_String) || (object->type & cJSON_IsReference))
+    if ((object == NULL) || !(object->type & cJSON_String) || (object->type & cJSON_IsReference))
+    {
+        return NULL;
+    }
+    /* return NULL if the object is corrupted */
+    if (object->valuestring == NULL)
     {
         return NULL;
     }
@@ -2264,7 +2269,7 @@ CJSON_PUBLIC(cJSON_bool) cJSON_InsertItemInArray(cJSON *array, int which, cJSON 
 {
     cJSON *after_inserted = NULL;
 
-    if (which < 0)
+    if (which < 0 || newitem == NULL)
     {
         return false;
     }
@@ -2273,6 +2278,11 @@ CJSON_PUBLIC(cJSON_bool) cJSON_InsertItemInArray(cJSON *array, int which, cJSON 
     if (after_inserted == NULL)
     {
         return add_item_to_array(array, newitem);
+    }
+
+    if (after_inserted != array->child && newitem->prev == NULL) {
+        /* return false if after_inserted is a corrupted array item */
+        return false;
     }
 
     newitem->next = after_inserted;


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `cJSON_SetValuestring` and  `cJSON_InsertItemInArray` that were cloned from `https://github.com/DaveGamble/cJSON` but did not receive the security patch.

###Details:
Affected Function: `cJSON_SetValuestring` and  `cJSON_InsertItemInArray` in file `gui/lv_100ask_xz_ai/src/cJSON.c`
Original Fix: https://github.com/DaveGamble/cJSON/commit/60ff122ef5862d04b39b150541459e7f5e35add8


###What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

###References:
https://github.com/DaveGamble/cJSON/commit/60ff122ef5862d04b39b150541459e7f5e35add8
https://github.com/advisories/GHSA-278h-99f9-m238
https://github.com/advisories/GHSA-xgc4-4vwx-6v94
